### PR TITLE
More mobile css fixes

### DIFF
--- a/pages/components/layout.js
+++ b/pages/components/layout.js
@@ -208,9 +208,7 @@ export default function Layout({children, transparent, home, dynamic, href}) {
 
             {!transparent && (
               <div className={styles.backToHome}>
-                <Link href={!dynamic ? "/" : "/countries"}>
-                  <a className={styles.backToHomeAnchor}>Back</a>
-                </Link>
+                <a href="javascript:history.go(-1)" className={styles.backToHomeAnchor}>Back</a>
               </div>
             )}
           </div>

--- a/pages/components/layout.module.scss
+++ b/pages/components/layout.module.scss
@@ -11,7 +11,7 @@
   margin: 0 auto;
 height: 200px;
 
-  @media (min-width: 480px) {
+  @media (min-width: 541px) {
     height: auto;
   }
 }
@@ -59,7 +59,7 @@ height: 200px;
 
   padding: 1em;
   width: 100%;
-  @media (min-width: 480px) {
+  @media (min-width: 541px) {
     height: 100px;
     padding: 1em 15%;
   }
@@ -76,13 +76,13 @@ height: 200px;
       list-style: none;
       display: inline-block;
       margin: 0 0.5em;
-      @media (min-width: 480px) {
+      @media (min-width: 541px) {
         margin: 0 1.5em;
       }
 
       &__socialLinks {
         margin: 0 0.5em;
-        @media (min-width: 480px) {
+        @media (min-width: 541px) {
           margin: 0 0.5em 0.5em;
         }
       }

--- a/pages/components/layout.module.scss
+++ b/pages/components/layout.module.scss
@@ -11,7 +11,7 @@
   margin: 0 auto;
 height: 200px;
 
-  @media (min-width: 375px) {
+  @media (min-width: 480px) {
     height: auto;
   }
 }
@@ -59,7 +59,7 @@ height: 200px;
 
   padding: 1em;
   width: 100%;
-  @media (min-width: 375px) {
+  @media (min-width: 480px) {
     height: 100px;
     padding: 1em 15%;
   }
@@ -76,13 +76,13 @@ height: 200px;
       list-style: none;
       display: inline-block;
       margin: 0 0.5em;
-      @media (min-width: 375px) {
+      @media (min-width: 480px) {
         margin: 0 1.5em;
       }
 
       &__socialLinks {
         margin: 0 0.5em;
-        @media (min-width: 375px) {
+        @media (min-width: 480px) {
           margin: 0 0.5em 0.5em;
         }
       }

--- a/public/sass/main.scss
+++ b/public/sass/main.scss
@@ -76,19 +76,19 @@ z-index: 9999999999999999;
   flex-direction: column;
   text-align: left;
   font-size: 18px;
-  @media (min-width: 375px) {
+  @media (min-width: 480px) {
     flex-direction: row;
   }
 
   &__item {
     align-self: stretch;
     margin: 0.5em 0 0;
-    @media (min-width: 375px) {
+    @media (min-width: 480px) {
       margin: 5em 0 0;
     }
     &--text {
 
-      @media (min-width: 375px) {
+      @media (min-width: 480px) {
         width: 55%;
         padding: 0 2em 0;
       }
@@ -108,7 +108,7 @@ z-index: 9999999999999999;
   flex-wrap: wrap;
   justify-content: flex-start;
   text-align: left;
-  @media (min-width: 375px) {
+  @media (min-width: 480px) {
 
   }
 
@@ -116,13 +116,13 @@ z-index: 9999999999999999;
     border-radius: 5px;
     padding: 1em;
     width: auto;
-    @media (min-width: 375px) {
+    @media (min-width: 480px) {
       margin: 0 1em 4em;
       width: 20%;
     }
     &--width2 {
       width: auto;
-      @media (min-width: 375px) {
+      @media (min-width: 480px) {
         margin: 0 1em 4em;
         width: 50%;
       }
@@ -131,7 +131,7 @@ z-index: 9999999999999999;
   &__title {
     font-size: 16px;
     margin: 0 0 0.5em;
-    @media (min-width: 375px) {
+    @media (min-width: 480px) {
       font-size: 20px;
     }
   }

--- a/public/sass/main.scss
+++ b/public/sass/main.scss
@@ -76,19 +76,19 @@ z-index: 9999999999999999;
   flex-direction: column;
   text-align: left;
   font-size: 18px;
-  @media (min-width: 480px) {
+  @media (min-width: 541px) {
     flex-direction: row;
   }
 
   &__item {
     align-self: stretch;
     margin: 0.5em 0 0;
-    @media (min-width: 480px) {
+    @media (min-width: 541px) {
       margin: 5em 0 0;
     }
     &--text {
 
-      @media (min-width: 480px) {
+      @media (min-width: 541px) {
         width: 55%;
         padding: 0 2em 0;
       }
@@ -108,7 +108,7 @@ z-index: 9999999999999999;
   flex-wrap: wrap;
   justify-content: flex-start;
   text-align: left;
-  @media (min-width: 480px) {
+  @media (min-width: 541px) {
 
   }
 
@@ -116,13 +116,13 @@ z-index: 9999999999999999;
     border-radius: 5px;
     padding: 1em;
     width: auto;
-    @media (min-width: 480px) {
+    @media (min-width: 541px) {
       margin: 0 1em 4em;
       width: 20%;
     }
     &--width2 {
       width: auto;
-      @media (min-width: 480px) {
+      @media (min-width: 541px) {
         margin: 0 1em 4em;
         width: 50%;
       }
@@ -131,7 +131,7 @@ z-index: 9999999999999999;
   &__title {
     font-size: 16px;
     margin: 0 0 0.5em;
-    @media (min-width: 480px) {
+    @media (min-width: 541px) {
       font-size: 20px;
     }
   }

--- a/public/sass/main.scss
+++ b/public/sass/main.scss
@@ -116,16 +116,12 @@ z-index: 9999999999999999;
     border-radius: 5px;
     padding: 1em;
     width: auto;
-    @media (min-width: 541px) {
+    @media (min-width: 541px) and (max-width: 720px) {
       margin: 0 1em 4em;
-      width: 20%;
     }
-    &--width2 {
-      width: auto;
-      @media (min-width: 541px) {
-        margin: 0 1em 4em;
-        width: 50%;
-      }
+    @media (min-width: 721px) {
+      margin: 0 1em 4em;
+      width: 45%;
     }
   }
   &__title {

--- a/public/sass/utils.module.scss
+++ b/public/sass/utils.module.scss
@@ -67,7 +67,7 @@
   font-weight: 100;
   margin: 0;
   text-align: center;
-  @media (min-width: 541px) {
+  @media (min-width: 720px) {
     font-size: 135px;
   }
 

--- a/public/sass/utils.module.scss
+++ b/public/sass/utils.module.scss
@@ -49,13 +49,6 @@
     color: var(--gray-black);
     height: auto;
     width: 100%;
-    @media (min-width: 541px) {
-      background-image: url('../../public/img/_backgrounds/banner-bg.png');
-      background-repeat: no-repeat;
-      background-position: 0 0;
-      background-clip: border-box;
-      background-size: 100%;
-    }
   }
 
 }
@@ -139,7 +132,12 @@
   left: 0;
   padding: 10em 1em 0;
   @media (min-width: 541px) {
-    background-color: transparent;
+    background-image: url('../../public/img/_backgrounds/banner-bg.png');
+    background-repeat: no-repeat;
+    background-position: 0 0;
+    background-clip: border-box;
+    background-size: 100%;
+    background-color: #3F3F56;
     padding: 7em 15% 0;
   }
 

--- a/public/sass/utils.module.scss
+++ b/public/sass/utils.module.scss
@@ -146,11 +146,17 @@
   &Content {
     margin: 1em 0 0;
     position: relative;
-    @media (max-width: 480px) {
-      margin: 10% 0 0;
-    };
-    @media (min-width: 541px), (max-width: 320px){
+    @media (max-width: 275px){
+      margin: 175px 0 0;
+    }
+    @media (min-width: 276px) and (max-width: 540px){
       margin: 20% 0 0;
+    }
+    @media (min-width: 541px) and (max-width: 649px) {
+      margin: 350px 0 0;
+    }
+    @media (min-width: 650px){
+      margin: 300px 0 0;
     }
   }
 }

--- a/public/sass/utils.module.scss
+++ b/public/sass/utils.module.scss
@@ -1,7 +1,7 @@
 .wrapper {
   text-align: center;
   padding: 1em 0;
-  @media (min-width: 480px) {
+  @media (min-width: 541px) {
     padding: 2em 0;
   }
   &__content {
@@ -9,13 +9,13 @@
     padding: 19.5em 1em 0;
     text-align: center;
     position: relative;
-    @media (min-width: 480px) {
+    @media (min-width: 541px) {
       padding: 10em 2em 0;
       min-height: 100vh;
     }
     &Intro {
       padding: 7em 1em;
-      @media (min-width: 480px) {
+      @media (min-width: 541px) {
         padding: 10em 15% 7em;
       }
     }
@@ -27,7 +27,7 @@
     height: auto;
     padding: 12em 1em 0;
     width: 100%;
-    @media (min-width: 480px) {
+    @media (min-width: 541px) {
       padding: 12em 2em 7em;
       min-height: 100vh;
     }
@@ -35,7 +35,7 @@
       padding: 5em 1em 0;
       background: var(--very-light-gray);
       color: #000;
-      @media (min-width: 480px) {
+      @media (min-width: 541px) {
         padding: 5em 2em 7em;
       }
     }
@@ -49,7 +49,7 @@
     color: var(--gray-black);
     height: auto;
     width: 100%;
-    @media (min-width: 480px) {
+    @media (min-width: 541px) {
       background-image: url('../../public/img/_backgrounds/banner-bg.png');
       background-repeat: no-repeat;
       background-position: 0 0;
@@ -67,7 +67,7 @@
   font-weight: 100;
   margin: 0;
   text-align: center;
-  @media (min-width: 480px) {
+  @media (min-width: 541px) {
     font-size: 135px;
   }
 
@@ -78,7 +78,7 @@
   &Micro {
     font-size: 26px;
     margin: 0 0 1em;
-    @media (min-width: 480px) {
+    @media (min-width: 541px) {
       font-size: 36px;
     }
   }
@@ -86,7 +86,7 @@
 .subtitle {
   font-size: 36px;
   font-weight: 400;
-  @media (min-width: 480px) {
+  @media (min-width: 541px) {
     font-size: 65px;
   }
 }
@@ -94,7 +94,7 @@
   text-align: center;
   font-size: 1em;
   padding: 1em 0;
-  @media (min-width: 480px) {
+  @media (min-width: 541px) {
     font-size: 24px;
     padding: 2em 0;
   }
@@ -102,14 +102,14 @@
 
 .caption {
   padding: 2em 0 0;
-  @media (min-width: 480px) {
+  @media (min-width: 541px) {
     padding: 2em 7em 0;
   }
 }
 
 .excerpt {
   font-size: 1em;
-  @media (min-width: 480px) {
+  @media (min-width: 541px) {
     font-size: 18px;
   }
 }
@@ -138,7 +138,7 @@
   top: 0;
   left: 0;
   padding: 10em 1em 0;
-  @media (min-width: 480px) {
+  @media (min-width: 541px) {
     background-color: transparent;
     padding: 7em 15% 0;
   }
@@ -146,7 +146,7 @@
   &Content {
     margin: 1em 0 0;
     position: relative;
-    @media (min-width: 480px) {
+    @media (min-width: 541px) {
       margin: 20% 0 0;
     }
   }
@@ -158,7 +158,7 @@
   margin: 2em 0 2em;
   padding: 1em;
   font-weight: 500;
-  @media (min-width: 480px) {
+  @media (min-width: 541px) {
     margin: 3em 0 2em;
     padding: 1em 2em;
   }

--- a/public/sass/utils.module.scss
+++ b/public/sass/utils.module.scss
@@ -146,7 +146,10 @@
   &Content {
     margin: 1em 0 0;
     position: relative;
-    @media (min-width: 541px) {
+    @media (max-width: 480px) {
+      margin: 10% 0 0;
+    };
+    @media (min-width: 541px), (max-width: 320px){
       margin: 20% 0 0;
     }
   }


### PR DESCRIPTION
Fixes the social media buttons sometimes being oval
For web and tablets: extends the dark background at the top of the countries page so that the light text subtitle can be read
Fixes the images on the countries page sometimes being over the title or subtitle
Tries to fix the alignment of the countries on the countries page
Fixes the back button on the about and specific countries pages